### PR TITLE
Update the storybook docs.

### DIFF
--- a/stories/Overview.stories.mdx
+++ b/stories/Overview.stories.mdx
@@ -28,11 +28,11 @@ Find the latest status on [the roadmap and board](https://github.com/orgs/vector
 
 ## Using Compound
 
-While we're in early design & development, Compound is primarily built for and consumed by the Element core team. As Compound matures, we plan to open access to as much of Compound as possible.
+Compound is primarily built for and maintained by the Element core team. The code is open and available for anyone to use.
 
-In the meanwhile, if you're on the core team, start using Compound to:
+If you're on the core team, start using Compound to:
 
-- Design: Set up Figma with shared libraries and plugins. Start designing using styles and components.
+- Design: Set up Figma with shared libraries and plugins (core team only). Start designing using styles and components.
 - Develop: Familiarise yourself with packages and workflows.
 
 ## Contributing

--- a/stories/content/Overview.stories.mdx
+++ b/stories/content/Overview.stories.mdx
@@ -10,4 +10,4 @@ Writing for our website and marketing channels is one thing. Writing for our app
 
 These guidelines are primarily for Product Designers or Developers who are writing for our marketing channels, Element apps, or admin tools, but they can also be used by anyone who’s developing content.
 
-For general guidance, you can also check out the [Element Brand Guidelines](https://www.figma.com/file/KX5Q0fauRZqn3JjYrxUqdk/Element-Brand-guidelines?node-id=2456%3A4018&t=qLPJXfA60jsDnbPe-1) to learn more about our overall messaging strategy, brand campaign, unique sell propositions, and design assets.
+For general guidance, you can also check out the Element Brand Guidelines Figma document to learn more about our overall messaging strategy, brand campaign, unique sell propositions, and design assets.

--- a/stories/design/GetStarted.stories.mdx
+++ b/stories/design/GetStarted.stories.mdx
@@ -4,7 +4,7 @@ import { Meta } from "@storybook/addon-docs";
 
 # Getting started as a designer
 
-Available styles can be found in the [Compound Styles Figma document](https://www.figma.com/file/PpKepmHKGikp33Ql7iivbn/Compound-Styles?node-id=22%3A2763&t=UAtRgYRpQ2xofvM3-1).
+Available styles can be found in the Compound Styles Figma document.
 They are generated from our set of design tokens.
 
 Themes can be switched using the [Themer Figma plugin](https://www.figma.com/community/plugin/731176732337510831/Themer).

--- a/stories/design/Marketing.stories.mdx
+++ b/stories/design/Marketing.stories.mdx
@@ -10,4 +10,4 @@ While the primary goal with Compound is to improve core product design, it can a
 * **Typography:** Use Compound Web typography styles as a baseline for body content on [element.io](https://www.element.io), again for web accessibility.
 * **Iconography:** Use Compound iconography to promote consistency in and out of app.
 
-Otherwise, extend with marketing specific styles and assets in the [Compound Marketing](https://www.figma.com/file/LxzEBh0R9x8bkdquuGD82i/Compound-Marketing?type=design&node-id=129%3A4461&t=8f90tk99ximZAMxO-1) shared Figma library.
+Otherwise, extend with marketing specific styles and assets in the Compound Marketing shared Figma library.

--- a/stories/design/contributing.stories.mdx
+++ b/stories/design/contributing.stories.mdx
@@ -45,8 +45,8 @@ Counter-intuitively, native mobile components take the longest to add to Compoun
 
 ### Contributing an icon
 
-- Optimise for personal velocity while ideating, by using icons from the previous team library, our copy of the [Material UI Rounded icon set in our shared workspace](<https://www.figma.com/file/VOQIMYq5WQH5C4ptZ77WsC/Material-Design-Icons-(Community)?node-id=2402%3A2207&t=CocVMe5ak2YeExGi-1>), or by drawing and creating new components locally in your Figma document
-- Once you're confident in your design and the use of an icon, paste it in the [Compound - Icon drafting](https://www.figma.com/file/9VUPAN6PjlmqPe1g2s3iPS/Compound---Icon-drafting?node-id=0%3A1&t=9wKkC0cJ6DwETrfD-1) Figma document, following the guidelines.
+- Optimise for personal velocity while ideating, by using icons from the previous team library, our copy of the Material UI Rounded icon set in our shared workspace, or by drawing and creating new components locally in your Figma document
+- Once you're confident in your design and the use of an icon, paste it in the Compound - Icon drafting Figma document, following the guidelines.
 - **Don't** worry about filing a GitHub issue. We'd like to avoid busywork and action icons quickly where possible, and will just use the Figma comment chain and internal rooms for any discussion. If we can't action them quickly, we may port to a GitHub issue ourselves to track and batch with other icon requests.
 - Then, once the icon is a part of the shared team library in Figma we'll let you know when the icon or icons are integrated. Then:
   - You can swap replace icon instances in your designs with the newly formed ones in the shared Compound team library.

--- a/stories/design/styles.stories.mdx
+++ b/stories/design/styles.stories.mdx
@@ -4,10 +4,4 @@ import { Meta } from "@storybook/addon-docs";
 
 # Styles
 
-<iframe
-  style={{ border: 0 }}
-  width="100%"
-  height="100%"
-  src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FPpKepmHKGikp33Ql7iivbn%2FCompound-Styles%3Fnode-id%3D22%253A2763%26t%3DUAtRgYRpQ2xofvM3-1"
-  allowfullscreen
-></iframe>
+Colour styles can be found in the Compound Styles Figma document.

--- a/stories/design/typography.stories.mdx
+++ b/stories/design/typography.stories.mdx
@@ -4,10 +4,4 @@ import { Meta } from "@storybook/addon-docs";
 
 # Typography
 
-<iframe
-  style={{ border: 0 }}
-  width="100%"
-  height="100%"
-  src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FPpKepmHKGikp33Ql7iivbn%2FCompound-Styles%3Fnode-id%3D22%253A2762%26t%3DUAtRgYRpQ2xofvM3-1"
-  allowfullscreen
-></iframe>
+Typography can be found in the Typography page of the Compound Styles Figma document.

--- a/stories/foundations/Iconography.stories.mdx
+++ b/stories/foundations/Iconography.stories.mdx
@@ -16,7 +16,7 @@ Compound favours consistent iconography cross-platform. We use:
 
 ### Contributing an icon
 
-- Optimise for personal velocity while ideating, by [using icons from the previous team library](https://www.figma.com/file/X4XTH9iS2KGJ2wFKDqkyed/ZzzArchive%2FCompound?node-id=1373%3A0&t=hxOtgeSXJ76AmQk6-1), our copy of the Material UI Rounded icon set in our shared workspace, or by drawing and creating new components locally in your Figma document
+- Optimise for personal velocity while ideating, by using icons from the previous team library, our copy of the Material UI Rounded icon set in our shared workspace, or by drawing and creating new components locally in your Figma document
 - Once you're confident in your design and the use of an icon, paste it in the [Compound - Icon drafting]() Figma document, following the guidelines.
 - Then, once the icon is a part of the shared team library in Figma we'll let you know when the icon or icons are integrated. Then:
     - You can swap replace icon instances in your designs with the newly formed ones in the shared Compound team library.


### PR DESCRIPTION
We're removing the references to private Figma documents as they aren't particularly helpful on public documentation.